### PR TITLE
Fix async audit for cases where tag is preloaded.

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/audits/async-ad-tags.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/async-ad-tags.js
@@ -16,7 +16,7 @@ const array = require('../utils/array.js');
 const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 const {auditNotApplicable} = require('../utils/builder');
 const {Audit} = require('lighthouse');
-const {isGptTag} = require('../utils/resource-classification');
+const {isGptTag, isStaticRequest} = require('../utils/resource-classification');
 const {URL} = require('url');
 
 /**
@@ -26,7 +26,9 @@ const {URL} = require('url');
 function isAsync(tagReq) {
   // Use request priority as proxy to determine if script tag is asynchronous.
   // See https://bugs.chromium.org/p/chromium/issues/detail?id=408229.
-  return tagReq.priority == 'Low';
+  // If preload, priority will be `High`, assume async in that case.
+  // TODO(jburger): Properly handle preload && !async case.
+  return tagReq.priority == 'Low' || isStaticRequest(tagReq);
 }
 
 /** @inheritDoc */

--- a/lighthouse-plugin-ad-speed-insights/audits/static-ad-tags.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/static-ad-tags.js
@@ -16,17 +16,8 @@ const array = require('../utils/array.js');
 const NetworkRecords = require('lighthouse/lighthouse-core/computed/network-records');
 const {auditNotApplicable} = require('../utils/builder');
 const {Audit} = require('lighthouse');
-const {isGptTag} = require('../utils/resource-classification');
+const {isGptTag, isStaticRequest} = require('../utils/resource-classification');
 const {URL} = require('url');
-
-/**
- * @param {LH.Artifacts.NetworkRequest} tagReq
- * @return {boolean}
- */
-function isStatic(tagReq) {
-  // Use initiator type to determine if tag was loaded statically.
-  return ['parser', 'preload'].includes(tagReq.initiator.type);
-}
 
 /** @inheritDoc */
 class StaticAdTags extends Audit {
@@ -62,7 +53,7 @@ class StaticAdTags extends Audit {
       return auditNotApplicable('No tag requested.');
     }
 
-    const numStatic = array.count(tagReqs, isStatic);
+    const numStatic = array.count(tagReqs, isStaticRequest);
     const numTags = tagReqs.length;
 
     return {

--- a/lighthouse-plugin-ad-speed-insights/test/audits/async-ad-tags_test.js
+++ b/lighthouse-plugin-ad-speed-insights/test/audits/async-ad-tags_test.js
@@ -44,12 +44,19 @@ describe('AsyncAdTags', async () => {
       {
         desc: 'should fail unless all ad tags are async',
         networkRecords: [
-          {priority: 'Low', url: 'http://www.googletagservices.com/tag/js/gpt.js'},
-          {priority: 'High', url: 'http://www.googletagservices.com/tag/js/gpt.js'},
-          {priority: 'Low', url: 'http://www.googletagservices.com/tag/js/gpt.js'},
-          {priority: 'Low', url: 'http://www.googletagservices.com/tag/js/gpt.js'},
+          {priority: 'Low', url: 'http://www.googletagservices.com/tag/js/gpt.js', initiator: {type: 'script'}},
+          {priority: 'High', url: 'http://www.googletagservices.com/tag/js/gpt.js', initiator: {type: 'script'}},
+          {priority: 'Low', url: 'http://www.googletagservices.com/tag/js/gpt.js', initiator: {type: 'script'}},
+          {priority: 'Low', url: 'http://www.googletagservices.com/tag/js/gpt.js', initiator: {type: 'script'}},
         ],
         expectedRawVal: false,
+      },
+      {
+        desc: 'should assume async if loaded statically',
+        networkRecords: [
+          {priority: 'High', url: 'http://www.googletagservices.com/tag/js/gpt.js', initiator: {type: 'preload'}},
+        ],
+        expectedRawVal: true,
       },
     ];
 

--- a/lighthouse-plugin-ad-speed-insights/utils/resource-classification.js
+++ b/lighthouse-plugin-ad-speed-insights/utils/resource-classification.js
@@ -99,6 +99,16 @@ function getHeaderBidder(url) {
   return false;
 }
 
+
+/**
+ * @param {LH.Artifacts.NetworkRequest} request
+ * @return {boolean}
+ */
+function isStaticRequest(request) {
+  // Use initiator type to determine if tag was loaded statically.
+  return ['parser', 'preload'].includes(request.initiator.type);
+}
+
 module.exports = {
   isGoogleAds,
   hasAdRequestPath,
@@ -108,4 +118,5 @@ module.exports = {
   isImplTag,
   containsAnySubstring,
   getHeaderBidder,
+  isStaticRequest,
 };


### PR DESCRIPTION
Resolve https://github.com/googleads/ad-speed-insights/issues/4
This is a temporary fix, this assumes that preloaded tags are loaded using `async` tag. Will explicitly check in future.