### PR TITLE
Expand the scope of the long tasks audit

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/ad-blocking-tasks.js
@@ -21,7 +21,7 @@ const {URL} = require('url');
 /**
  * Threshold for long task duration (ms), from https://github.com/w3c/longtasks.
  */
-const LONG_TASK_DUR_MS = 100;
+const LONG_TASK_DUR_MS = 50;
 
 /**
  * Table headings for audits details sections.

--- a/lighthouse-plugin-ad-speed-insights/audits/ad-blocking-tasks.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/ad-blocking-tasks.js
@@ -18,10 +18,11 @@ const {auditNotApplicable} = require('../utils/builder');
 const {Audit} = require('lighthouse');
 const {isGoogleAds, isGpt} = require('../utils/resource-classification');
 const {URL} = require('url');
+
 /**
  * Threshold for long task duration (ms), from https://github.com/w3c/longtasks.
  */
-const LONG_TASK_DUR_MS = 50;
+const LONG_TASK_DUR_MS = 100;
 
 /**
  * Table headings for audits details sections.
@@ -29,7 +30,7 @@ const LONG_TASK_DUR_MS = 50;
  */
 const HEADINGS = [
   {key: 'name', itemType: 'text', text: 'Type'},
-  {key: 'script', itemType: 'url', text: 'Attributable Script'},
+  {key: 'script', itemType: 'url', text: 'Attributable URL'},
   {key: 'startTime', itemType: 'ms', text: 'Start', granularity: 1},
   {key: 'endTime', itemType: 'ms', text: 'End', granularity: 1},
   {key: 'duration', itemType: 'ms', text: 'Duration', granularity: 1},
@@ -126,6 +127,8 @@ function attributableUrl(longTask, knownScripts) {
     // permitting non-script URLs.
     return attributableUrl(longTask, null);
   }
+  // TODO(warrengm): Investigate which we return empty strings or non-script
+  // URLs.
   return '';
 }
 
@@ -216,6 +219,7 @@ class AdBlockingTasks extends Audit {
 
       blocking.push({
         name,
+        // TODO(warrengm): Format the display URL so it fits on one line
         script: displayUrl,
         startTime: longTask.startTime,
         endTime: longTask.endTime,


### PR DESCRIPTION
Change log:

- Include all long tasks before ad responses, not ones that directly block the ad response.
- Use `duration` rather than `selfTime` to find long tasks. Previously the audit was skipping tasks that were composed of many small functions. Note that child and parent long tasks may both be included, but only if the child has a distinct URL from its parent.
- Show at most 10 long task

We should to consider tuning the failing conditions for this audit (e.g. a single 51 ms task seems relatively minor and should not be failing)