### PR TITLE
Critical path: remove false positives and abbreviate overlapping requests in output

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/ad-request-critical-path.js
@@ -224,7 +224,7 @@ class AdRequestCriticalPath extends Audit {
       startTime: (req.startTime - pageStartTime) * 1000,
       endTime: (req.endTime - pageStartTime) * 1000,
       duration: (req.endTime - req.startTime) * 1000,
-    }));
+    })).filter((r) => r.duration > 30 && r.startTime > 0);
     tableView = computeSummaries(tableView);
 
     const depth = computeDepth(tableView);

--- a/lighthouse-plugin-ad-speed-insights/audits/ad-request-critical-path.js
+++ b/lighthouse-plugin-ad-speed-insights/audits/ad-request-critical-path.js
@@ -157,7 +157,7 @@ function computeDepth(requests) {
  * @return {string}
  */
 function getAbbreviatedUrl(url) {
-  const u = new URL(trimQuery(url));
+  const u = new URL(trimUrl(url));
   const parts = u.pathname.split('/');
   if (parts.length > 4) {
     u.pathname = [...parts.splice(0, 4), '...'].join('/');
@@ -170,9 +170,12 @@ function getAbbreviatedUrl(url) {
  * @param {string} url
  * @return {string}
  */
-function trimQuery(url) {
+function trimUrl(url) {
   const u = new URL(url);
-  return u.origin + u.pathname;
+  const PATH_MAX = 60;
+  const path = u.pathname.length > PATH_MAX ?
+    u.pathname.substr(0, PATH_MAX) + '...' : u.pathname;
+  return u.origin + path;
 }
 
 /**
@@ -218,7 +221,7 @@ class AdRequestCriticalPath extends Audit {
     }
     const pageStartTime = getPageStartTime(networkRecords);
     let tableView = blockingRequests.map((req) => ({
-      url: trimQuery(req.url),
+      url: trimUrl(req.url),
       abbreviatedUrl: getAbbreviatedUrl(req.url),
       type: req.resourceType,
       startTime: (req.startTime - pageStartTime) * 1000,

--- a/lighthouse-plugin-ad-speed-insights/utils/bidder-patterns.js
+++ b/lighthouse-plugin-ad-speed-insights/utils/bidder-patterns.js
@@ -218,8 +218,7 @@ module.exports = [
   {
     label: 'IndexExchange',
     patterns: [
-      '^http[s]?:\/\/as\.casalemedia\.com\/cygnus.*',
-      '^http[s]?:\/\/as-sec\.casalemedia\.com\/cygnus.*',
+      '^http[s]?:\/\/as(-sec)?\.casalemedia\.com\/(cygnus|headertag).*',
     ],
   },
   {

--- a/lighthouse-plugin-ad-speed-insights/utils/graph.js
+++ b/lighthouse-plugin-ad-speed-insights/utils/graph.js
@@ -128,6 +128,7 @@ function addInitiatedRequests(
           r.endTime < parentReq.startTime);
 
   for (const initiatedReq of initiatedRequests) {
+    // TODO(warrengm): Check for JSONP and Fetch requests.
     const blocking =
       initiatedReq.resourceType == 'XHR' &&
       isXhrCritical(

--- a/lighthouse-plugin-ad-speed-insights/utils/graph.js
+++ b/lighthouse-plugin-ad-speed-insights/utils/graph.js
@@ -96,8 +96,7 @@ function isXhrCritical(xhrReq, networkRecords, traceEvents, criticalRequests) {
       .filter((t) => (t.args.data || {}).url == xhrReq.url);
   // TODO(warrengm): Investigate if we can get async stack traces here.
   const frames = flatten(
-    relevantEvents.map((t) => (t.args.data || {}).stackTrace || [])
-  );
+    relevantEvents.map((t) => (t.args.data || {}).stackTrace || []));
   /** @type {Set<string>} */
   const urls =
       new Set(frames.map(/** @param {{url: string}} f */ (f) => f.url));
@@ -130,12 +129,9 @@ function addInitiatedRequests(
 
   for (const initiatedReq of initiatedRequests) {
     const blocking =
-      initiatedReq.resourceType == 'XHR' ?
-        // Verify the XHR is actually blocking.
-        isXhrCritical(
-          initiatedReq, networkRecords, traceEvents, criticalRequests) :
-        // If there are no initiated requests, then it's probably JSONP.
-        !networkRecords.find((r) => r.initiatorRequest == initiatedReq);
+      initiatedReq.resourceType == 'XHR' &&
+      isXhrCritical(
+        initiatedReq, networkRecords, traceEvents, criticalRequests);
     if (blocking) {
       getCriticalGraph(
         networkRecords, initiatedReq, traceEvents, criticalRequests);


### PR DESCRIPTION
This PR does a few things:

1. Remove false positive script outputs. The previous JSONP heuristic was too broad. I remove this heuristic until we have a better one in place. I don't expect this to matter too much since jsonp is relatively rare today.

2. Abbreviate URLs of overlapping requests with the same path to improve report brevity.

3. Filter out the document and any short (<30ms) requests from output table.