### PR TITLE
Correct contributing link

### DIFF
--- a/lighthouse-plugin-ad-speed-insights/package.json
+++ b/lighthouse-plugin-ad-speed-insights/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lighthouse-plugin-ad-speed-insights",
-  "version": "0.0.3.5",
+  "version": "0.0.3.6",
   "description": "Ad-aware plugin for lighthouse.",
   "license": "Apache-2.0",
   "main": "plugin.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ad-speed-insights-wrapper",
-  "version": "0.0.3.5",
+  "version": "0.0.3.6",
   "description": "Wrapper for Ad Speed Insights lighthouse plugin.",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
There is no CONTRIBUTING.md in the main directory, causing the link in the README to break. I have corrected this link to go to the Publisher Ads Audits for Lighthouse's contribution guide.